### PR TITLE
Adding sinks to TableFmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This tool works similar to `jq`.
 Where you pass a set of filters or queries to mutate the csv data or extract lines that interest you.
 
 There are various output modifiers like:
- - csv
- - markdown table
- - JSON
- - JSON
- - HTML
+ - `csv`: Default csv output.
+ - `md`: Markdown table.
+ - `json`: Json output.
+ - `pretty`: Pretty ASCII table similar to markdown.
+ - `html`: HTML table.
 
 Here is a simple usage of `table`:
 ![Simple example usage](assets/table_usage_simple.png)
@@ -33,6 +33,22 @@ go install github.com/soerlemans/table@latest
 ```
 
 Diclaimer: This project is not feature complete or production ready, bugs will arise.
+
+## Example
+Here is an example usage of `table`:
+```shell
+table '.Department == "Engineering" | head 4 | sort "Username" | md "Username", "First name", "Last name", "Department" ' data/example.csv
+```
+
+Output:
+```
+| Username       | First name | Last name | Department  |
+| -------------- | ---------- | --------- | ----------- |
+| jenkins46      | Mary       | Jenkins   | Engineering |
+| jenkins9993424 | Bob        | Jenkins   | Engineering |
+| jenkins99999   | VanDame    | Jenkins   | Engineering |
+| jenkins9da33   | Herald     | Jenkins   | Engineering |
+```
 
 ## Help
 ```

--- a/data/example.csv
+++ b/data/example.csv
@@ -7,3 +7,8 @@ jenkins46,9346,14ju73,mj9346,Mary,Jenkins,Engineering,Manchester
 smith79,5079,09ja61,js5079,Jamie,Smith,Engineering,Manchester
 smith80,3333,09ja65,xqfj79,Jamie,German,Engineering,Blackpool
 bobby,3133,09xj65,xjfjfl,John,Gale,R&D,Blackpool
+jenkins99999,1216,1jflxx,000346,VanDame,Jenkins,Engineering,Manchester
+jenkins99322,1216,1jflxx,000346,Clyde,Jenkins,Finance,Manchester
+jenkins9993424,1216,1jflxx,000346,Bob,Jenkins,Engineering,Manchester
+jenkins12344,1216,1jflxx,000346,Bobby,Jenkins,Finance,Manchester
+jenkins9da33,1216,1jflxx,000346,Herald,Jenkins,Engineering,Manchester

--- a/filter/grammar.yy
+++ b/filter/grammar.yy
@@ -67,30 +67,34 @@ keyword          : WHEN expr
 								 | TAIL rvalue
                  ;
 
-write_csv        : CSV
-                 | CSV STRING
-                 | CSV STRING COMMA parameter_list
+format_csv        : CSV
+                 | CSV parameter_list
                  ;
 
-write_md         : MD
-                 | MD STRING
-                 | MD STRING COMMA parameter_list
+format_md         : MD
+                 | MD parameter_list
                  ;
 
-write_json       : JSON
-                 | JSON STRING
-                 | JSON STRING COMMA parameter_list
+format_pretty     : PRETTY
+                 | PRETTY parameter_list
                  ;
 
-write_html       : HTML
-                 | HTML STRING
-                 | HTML STRING COMMA parameter_list
+format_json       : JSON
+                 | JSON parameter_list
                  ;
 
-write            : write_csv
-                 | write_md
-                 | write_json
-                 | write_html
+format_html       : HTML
+                 | HTML parameter_list
+                 ;
+
+format_out       : format_csv
+                 | format_md
+                 | format_pretty
+                 | format_json
+                 | format_html
+                 ;
+
+write_directive  : GT rvalue
                  ;
 
 
@@ -102,11 +106,11 @@ item             : keyword
 item_list        : // empty
                  | item_list PIPE item
                  | item
+                 | item_list PIPE format_out // A format_out should always be at the end (if it is there).
                  ;
 
 program          : item_list
-                 | item_list PIPE write // A write should always be at the end (if it is there).
-								 | write
+								 | format_out
                  ;
 
 %%

--- a/filter/ir/ir.go
+++ b/filter/ir/ir.go
@@ -37,6 +37,8 @@ const (
 	Pretty
 	Json
 	Html
+
+	WriteDirective
 )
 
 func (t InstructionType) String() string {
@@ -79,6 +81,9 @@ func (t InstructionType) String() string {
 		return "Json"
 	case Html:
 		return "Html"
+
+	case WriteDirective:
+		return "WriteDirective"
 	}
 
 	// Return unhandled case.

--- a/filter/ir/ir_vm.go
+++ b/filter/ir/ir_vm.go
@@ -4,6 +4,7 @@ import (
 	l "container/list"
 	"fmt"
 
+	s "github.com/soerlemans/table/out/sink"
 	tf "github.com/soerlemans/table/out/table_fmt"
 	td "github.com/soerlemans/table/table_data"
 	u "github.com/soerlemans/table/util"
@@ -22,7 +23,8 @@ type IrVm struct {
 	Table *td.TableData
 
 	// The formatter is in control of formatting the table in different formats.
-	Fmt tf.TableFmt
+	Fmt  tf.TableFmt
+	Sink s.Sink
 }
 
 // TODO: The index and tableData should be wrapped in a struct or something.

--- a/filter/ir/ir_vm.go
+++ b/filter/ir/ir_vm.go
@@ -392,6 +392,9 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 
 			this.Fmt.SetSort(index)
 
+			// Remove instruction.
+			this.Instructions.Remove(elem)
+
 		case NumericSort:
 			u.Logln("ExecIr: Applying numeric sort.")
 			val := inst.Operands[0]
@@ -401,6 +404,9 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			}
 
 			this.Fmt.SetNumericSort(index)
+
+			// Remove instruction.
+			this.Instructions.Remove(elem)
 
 			// TODO: Move somewhere else.
 		case Head:
@@ -416,6 +422,9 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			}
 
 			this.Fmt.SetHead(num)
+
+			// Remove instruction.
+			this.Instructions.Remove(elem)
 			break
 
 		case Tail:
@@ -431,6 +440,9 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			}
 
 			this.Fmt.SetTail(num)
+
+			// Remove instruction.
+			this.Instructions.Remove(elem)
 
 			// Output specifiers:
 		case Csv:

--- a/filter/ir/ir_vm.go
+++ b/filter/ir/ir_vm.go
@@ -310,7 +310,6 @@ func (this *IrVm) execFmt(t_elem *l.Element) error {
 	default:
 		u.Logf("execFmt: Error unhandeld InstructionType: %v", instType)
 		// TODO: Error out.
-		break
 	}
 
 	if newFmt != nil {
@@ -381,7 +380,6 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			if !cmp {
 				skip = true
 			}
-			break
 
 			// TODO: Move somewhere else.
 		case Sort:
@@ -393,7 +391,6 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			}
 
 			this.Fmt.SetSort(index)
-			break
 
 		case NumericSort:
 			u.Logln("ExecIr: Applying numeric sort.")
@@ -404,7 +401,6 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			}
 
 			this.Fmt.SetNumericSort(index)
-			break
 
 			// TODO: Move somewhere else.
 		case Head:
@@ -435,7 +431,6 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			}
 
 			this.Fmt.SetTail(num)
-			break
 
 			// Output specifiers:
 		case Csv:
@@ -448,6 +443,26 @@ func (this *IrVm) ExecIr(t_insts *InstructionList) error {
 			fallthrough
 		case Html:
 			this.execFmt(elem)
+
+		case WriteDirective:
+			val := inst.Operands[0]
+			u.Logf("ExecIr: Setting file sink %v", val)
+
+			path, err := this.resolveValue(val)
+			if err != nil {
+				return err
+			}
+
+			sink, err := s.InitFileSink(path)
+			if err != nil {
+				return err
+			}
+
+			// Update sink.
+			this.Fmt.SetSink(&sink)
+
+			// Remove instruction.
+			this.Instructions.Remove(elem)
 
 		default:
 			u.Logf("ExecIr: Error unhandeld InstructionType: %v", inst.Type)

--- a/filter/parse.go
+++ b/filter/parse.go
@@ -694,11 +694,13 @@ func item(t_stream *TokenStream) (InstPtr, error) {
 	} else if fmtPtr, err := formatOut(t_stream); validPtr(fmtPtr, err) {
 		inst = fmtPtr
 
+		// TODO: Simplify this bit here which is shared with the write directive check.
 		// We should end the filter list with a format_out statement.
 		if !t_stream.Eos() {
 			// Or if there is no write directive we should be at the end of the stream.
 			token := t_stream.Current()
 			if token.Type != GreaterThan {
+				fmt.Println(token)
 				return inst, errWriteDirective("item")
 			}
 		}
@@ -716,7 +718,8 @@ func itemList(t_stream *TokenStream) (InstListPtr, error) {
 	}
 
 	// Handle potential write directive.
-	if validPtr(list, err) {
+	// TODO: Simplify this bit here and the write directive selection.
+	if !t_stream.Eos() && validPtr(list, err) {
 		if writePtr, err := writeDirective(t_stream); validPtr(writePtr, err) {
 			addInstruction(&list, writePtr)
 		} else {

--- a/filter/parse.go
+++ b/filter/parse.go
@@ -550,14 +550,14 @@ func keyword(t_stream *TokenStream) (InstPtr, error) {
 	return inst, nil
 }
 
-func write(t_stream *TokenStream) (InstPtr, error) {
+func formatOut(t_stream *TokenStream) (InstPtr, error) {
 	var (
 		inst InstPtr
 		list ValueListPtr = new(ir.ValueList)
 		err  error
 	)
 
-	defer func() { logUnlessNil("write", inst) }()
+	defer func() { logUnlessNil("formatOut", inst) }()
 
 	// Guard clause.
 	if t_stream.Eos() {
@@ -644,6 +644,36 @@ func write(t_stream *TokenStream) (InstPtr, error) {
 	return inst, nil
 }
 
+func writeDirective(t_stream *TokenStream) (InstPtr, error) {
+	var inst InstPtr
+	defer func() { logUnlessNil("writeDirective", inst) }()
+
+	// Guard clause.
+	if t_stream.Eos() {
+		return inst, nil
+	}
+
+	token := t_stream.Current()
+	if token.Type == GreaterThan {
+		t_stream.Next()
+		if t_stream.Eos() {
+			return inst, errUnexpectedEos("writeDirective")
+		}
+
+		if argPtr, err := rvalue(t_stream); validPtr(argPtr, err) {
+			write := ir.InitInstruction(ir.WriteDirective, *argPtr)
+
+			inst = &write
+		} else {
+			// We must receive an argument for head.
+			return inst, errExpectedString("writeDirective", "rvalue")
+		}
+	}
+
+	return inst, nil
+}
+
+// Also contains the handling of the formatOut directive.
 func item(t_stream *TokenStream) (InstPtr, error) {
 	var inst InstPtr
 	defer func() { logUnlessNil("item", inst) }()
@@ -660,13 +690,17 @@ func item(t_stream *TokenStream) (InstPtr, error) {
 	} else if err != nil {
 		return inst, err
 
-		// Check for a writer specification.
-	} else if writePtr, err := write(t_stream); validPtr(writePtr, err) {
-		inst = writePtr
+		// Check for writer specification.
+	} else if fmtPtr, err := formatOut(t_stream); validPtr(fmtPtr, err) {
+		inst = fmtPtr
 
-		// If a writer is successfully parsed we should be at the end of stream.
+		// We should end the filter list with a format_out statement.
 		if !t_stream.Eos() {
-			return inst, errWriteDirective("item")
+			// Or if there is no write directive we should be at the end of the stream.
+			token := t_stream.Current()
+			if token.Type != GreaterThan {
+				return inst, errWriteDirective("item")
+			}
 		}
 	} else if err != nil {
 		return inst, err
@@ -676,7 +710,21 @@ func item(t_stream *TokenStream) (InstPtr, error) {
 }
 
 func itemList(t_stream *TokenStream) (InstListPtr, error) {
-	return parseList(t_stream, item, Pipe)
+	list, err := parseList(t_stream, item, Pipe)
+	if err != nil {
+		return list, err
+	}
+
+	// Handle potential write directive.
+	if validPtr(list, err) {
+		if writePtr, err := writeDirective(t_stream); validPtr(writePtr, err) {
+			addInstruction(&list, writePtr)
+		} else {
+			return list, errWriteDirective("itemList")
+		}
+	}
+
+	return list, nil
 }
 
 // This function is here purely just to match the grammary.yy.

--- a/out/sink/file_sink.go
+++ b/out/sink/file_sink.go
@@ -10,37 +10,33 @@ type FileSink struct {
 	File *os.File
 }
 
-func (this *FileSink) Writef(t_fmt string, t_args ...interface{}) error {
+func (this *FileSink) Writef(t_fmt string, t_args ...interface{}) {
 	str := fmt.Sprintf(t_fmt, t_args...)
 
 	_, err := this.File.WriteString(str)
 	if err != nil {
-		return err
+		panic(err)
 	}
-
-	return nil
 }
 
-func (this *FileSink) Writeln(t_args ...interface{}) error {
+func (this *FileSink) Writeln(t_args ...interface{}) {
 	str := fmt.Sprintln(t_args...)
 
 	_, err := this.File.WriteString(str)
 	if err != nil {
-		return err
+		panic(err)
 	}
-
-	return nil
 }
 
 func InitFileSink(t_path string) (FileSink, error) {
 	var sink FileSink
 
-	file, err := os.Open(t_path)
+	file, err := os.Create(t_path)
 	if err != nil {
 		return sink, err
 	}
 
-	// Set the file sink.l
+	// Set the file sink.
 	sink.File = file
 
 	return sink, nil

--- a/out/sink/sink.go
+++ b/out/sink/sink.go
@@ -6,6 +6,6 @@ import (
 
 // A format writer outputs structured rows in a formatted way.
 type Sink interface {
-	Writef(t_fmt string, t_args ...interface{}) error
-	Writeln(t_args ...interface{}) error
+	Writef(t_fmt string, t_args ...interface{})
+	Writeln(t_args ...interface{})
 }

--- a/out/sink/stdout_sink.go
+++ b/out/sink/stdout_sink.go
@@ -8,16 +8,12 @@ import (
 type StdoutSink struct {
 }
 
-func (this *StdoutSink) Writef(t_fmt string, t_args ...interface{}) error {
+func (this *StdoutSink) Writef(t_fmt string, t_args ...interface{}) {
 	fmt.Printf(t_fmt, t_args...)
-
-	return nil
 }
 
-func (this *StdoutSink) Writeln(t_args ...interface{}) error {
+func (this *StdoutSink) Writeln(t_args ...interface{}) {
 	fmt.Println(t_args...)
-
-	return nil
 }
 
 func InitStdoutSink() StdoutSink {

--- a/out/table_fmt/csv_fmt.go
+++ b/out/table_fmt/csv_fmt.go
@@ -1,8 +1,6 @@
 package table_fmt
 
 import (
-	"fmt"
-
 	td "github.com/soerlemans/table/table_data"
 )
 
@@ -17,11 +15,11 @@ func (this *CsvFmt) printRow(t_row td.TableDataRow) error {
 	var sep string
 	for _, index := range order {
 		cell := t_row[index]
-		fmt.Printf("%s%s", sep, cell)
+		this.writef("%s%s", sep, cell)
 
 		sep = ","
 	}
-	fmt.Println()
+	this.writeln()
 
 	return nil
 }
@@ -65,13 +63,11 @@ func (this *CsvFmt) Write() error {
 }
 
 func InitCsvFmt(t_label string) (CsvFmt, error) {
-	fmt_ := CsvFmt{}
+	base, err := InitBaseTableFmt(t_label)
+	format := CsvFmt{BaseTableFmt: base}
+	if err != nil {
+		return format, err
+	}
 
-	fmt_.Label = t_label
-	fmt_.SortCol = SortUnset
-	fmt_.NumericSortCol = SortUnset
-	fmt_.Head = HeadUnset
-	fmt_.Tail = TailUnset
-
-	return fmt_, nil
+	return format, nil
 }

--- a/out/table_fmt/html_fmt.go
+++ b/out/table_fmt/html_fmt.go
@@ -14,6 +14,9 @@ const (
 	Section
 	Row
 	Cell
+
+	// We use two spaces for indentation.
+	Identation string = "  "
 )
 
 type HtmlFmt struct {
@@ -21,41 +24,40 @@ type HtmlFmt struct {
 	BaseTableFmt
 }
 
-func indent(t_level IdentLevel, t_fmt string, t_args ...interface{}) {
+func (this *HtmlFmt) indent(t_level IdentLevel, t_fmt string, t_args ...interface{}) {
 	level := int(t_level)
 
 	// We use 2 spaces for indentation.
-	str := strings.Repeat("  ", level)
-
+	str := strings.Repeat(Identation, level)
 	format := fmt.Sprintf("%s%s\n", str, t_fmt)
 
-	fmt.Printf(format, t_args...)
+	this.writef(format, t_args...)
 }
 
 func (this *HtmlFmt) printRow(t_tag string, t_row td.TableDataRow) error {
 	order := this.GetOrder()
 
-	indent(Row, "<tr>")
+	this.indent(Row, "<tr>")
 	for _, index := range order {
 		cell := t_row[index]
 
-		indent(Cell, "<%s> %s </%s>", t_tag, cell, t_tag)
+		this.indent(Cell, "<%s> %s </%s>", t_tag, cell, t_tag)
 	}
-	indent(Row, "</tr>")
+	this.indent(Row, "</tr>")
 
 	return nil
 }
 
 func (this *HtmlFmt) printTableHeader() error {
-	indent(Section, "<thead>")
+	this.indent(Section, "<thead>")
 	err := this.printRow("td", this.Headers)
-	indent(Section, "</thead>")
+	this.indent(Section, "</thead>")
 
 	return err
 }
 
 func (this *HtmlFmt) printTableRows() error {
-	indent(Section, "<tbody>")
+	this.indent(Section, "<tbody>")
 	// Print per row.
 	for index, row := range this.Rows {
 		// Skip if we are not in bounds.
@@ -69,13 +71,13 @@ func (this *HtmlFmt) printTableRows() error {
 			return err
 		}
 	}
-	indent(Section, "</tbody>")
+	this.indent(Section, "</tbody>")
 
 	return nil
 }
 
 func (this *HtmlFmt) Write() error {
-	indent(Table, "<table>")
+	this.indent(Table, "<table>")
 	err := this.printTableHeader()
 	if err != nil {
 		return err
@@ -86,19 +88,17 @@ func (this *HtmlFmt) Write() error {
 		return err
 	}
 
-	indent(Table, "</table>")
+	this.indent(Table, "</table>")
 
 	return nil
 }
 
 func InitHtmlFmt(t_label string) (HtmlFmt, error) {
-	fmt_ := HtmlFmt{}
+	base, err := InitBaseTableFmt(t_label)
+	format := HtmlFmt{BaseTableFmt: base}
+	if err != nil {
+		return format, err
+	}
 
-	fmt_.Label = t_label
-	fmt_.SortCol = SortUnset
-	fmt_.NumericSortCol = SortUnset
-	fmt_.Head = HeadUnset
-	fmt_.Tail = TailUnset
-
-	return fmt_, nil
+	return format, nil
 }

--- a/out/table_fmt/json_fmt.go
+++ b/out/table_fmt/json_fmt.go
@@ -1,8 +1,6 @@
 package table_fmt
 
 import (
-	"fmt"
-
 	td "github.com/soerlemans/table/table_data"
 )
 
@@ -15,15 +13,15 @@ func (this *JsonFmt) printRow(t_row td.TableDataRow) error {
 	var sep string
 	order := this.GetOrder()
 
-	fmt.Printf("{ ")
+	this.writef("{ ")
 	for _, index := range order {
 		colName := this.Headers[index]
 		value := t_row[index]
 
-		fmt.Printf("%s\"%s\": \"%s\"", sep, colName, value)
+		this.writef("%s\"%s\": \"%s\"", sep, colName, value)
 		sep = ", "
 	}
-	fmt.Println(" }")
+	this.writeln(" }")
 
 	return nil
 }
@@ -58,13 +56,11 @@ func (this *JsonFmt) Write() error {
 }
 
 func InitJsonFmt(t_label string) (JsonFmt, error) {
-	fmt_ := JsonFmt{}
+	base, err := InitBaseTableFmt(t_label)
+	format := JsonFmt{BaseTableFmt: base}
+	if err != nil {
+		return format, err
+	}
 
-	fmt_.Label = t_label
-	fmt_.SortCol = SortUnset
-	fmt_.NumericSortCol = SortUnset
-	fmt_.Head = HeadUnset
-	fmt_.Tail = TailUnset
-
-	return fmt_, nil
+	return format, nil
 }

--- a/out/table_fmt/md_fmt.go
+++ b/out/table_fmt/md_fmt.go
@@ -72,9 +72,9 @@ func (this *MdFmt) printRow(t_row td.TableDataRow) error {
 		}
 
 		// Check if the column is selected.
-		fmt.Printf("| %-*s ", colWidth, cell)
+		this.writef("| %-*s ", colWidth, cell)
 	}
-	fmt.Println("|")
+	this.writeln("|")
 
 	return nil
 }
@@ -94,9 +94,9 @@ func (this *MdFmt) printTableHeaderSep() error {
 
 		// Check if the column is selected.
 		colSep := strings.Repeat("-", colWidth)
-		fmt.Printf("| %s ", colSep)
+		this.writef("| %s ", colSep)
 	}
-	fmt.Println("|")
+	this.writeln("|")
 
 	return nil
 }
@@ -168,18 +168,21 @@ func (this *MdFmt) Copy(t_fmt TableFmt) error {
 	tail := t_fmt.GetTail()
 	this.SetTail(tail)
 
+	sink := t_fmt.GetSink()
+	this.SetSink(sink)
+
 	return nil
 }
 
 func InitMdFmt(t_label string) (MdFmt, error) {
-	fmt_ := MdFmt{}
+	base, err := InitBaseTableFmt(t_label)
+	format := MdFmt{BaseTableFmt: base}
+	if err != nil {
+		return format, err
+	}
 
-	fmt_.Label = t_label
-	fmt_.ColWidth = make(map[int]int)
-	fmt_.SortCol = SortUnset
-	fmt_.NumericSortCol = SortUnset
-	fmt_.Head = HeadUnset
-	fmt_.Tail = TailUnset
+	// Markdown table specific init.
+	format.ColWidth = make(map[int]int)
 
-	return fmt_, nil
+	return format, nil
 }

--- a/out/table_fmt/pretty_fmt.go
+++ b/out/table_fmt/pretty_fmt.go
@@ -1,7 +1,6 @@
 package table_fmt
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -29,9 +28,9 @@ func (this *PrettyFmt) printTableHeaderSep() error {
 
 		// Check if the column is selected.
 		colSep := strings.Repeat("-", colWidth)
-		fmt.Printf("+ %s ", colSep)
+		this.writef("+ %s ", colSep)
 	}
-	fmt.Println("+")
+	this.writeln("+")
 
 	return nil
 }
@@ -68,14 +67,11 @@ func (this *PrettyFmt) Write() error {
 }
 
 func InitPrettyFmt(t_label string) (PrettyFmt, error) {
-	fmt_ := PrettyFmt{}
+	base, err := InitMdFmt(t_label)
+	format := PrettyFmt{MdFmt: base}
+	if err != nil {
+		return format, err
+	}
 
-	fmt_.Label = t_label
-	fmt_.ColWidth = make(map[int]int)
-	fmt_.SortCol = SortUnset
-	fmt_.NumericSortCol = SortUnset
-	fmt_.Head = HeadUnset
-	fmt_.Tail = TailUnset
-
-	return fmt_, nil
+	return format, nil
 }

--- a/out/table_fmt/table_fmt.go
+++ b/out/table_fmt/table_fmt.go
@@ -163,8 +163,8 @@ func (this *BaseTableFmt) InBounds(t_index int) bool {
 	// Default we are always inbounds.
 	var (
 		inBound     = false
-		headInBound = false
-		tailInBound = false
+		headIsUnset = false
+		tailIsUnset = false
 	)
 
 	head := this.GetHead()
@@ -185,10 +185,13 @@ func (this *BaseTableFmt) InBounds(t_index int) bool {
 	// Any negative values are seen as being unset.
 	if head > HeadUnset {
 		// If the index is below the head count we are in bounds.
-		headInBound = (t_index < head)
-		u.Logf("InBounds: %v = %d < %d", headInBound, t_index, head)
+		inBound = (t_index < head)
+		u.Logf("InBounds: %v = %d < %d", inBound, t_index, head)
+		if inBound {
+			return inBound
+		}
 	} else {
-		headInBound = true
+		headIsUnset = true
 	}
 
 	if tail > TailUnset {
@@ -196,13 +199,16 @@ func (this *BaseTableFmt) InBounds(t_index int) bool {
 		tailBound := (rowCount - 1) - tail
 
 		// If the index is above the tailBound we are in bounds.
-		tailInBound = (t_index > tailBound)
-		u.Logf("InBounds: %v = %d > %d", tailInBound, t_index, tailBound)
+		inBound = (t_index > tailBound)
+		u.Logf("InBounds: %v = %d > %d", inBound, t_index, tailBound)
+		if inBound {
+			return inBound
+		}
 	} else {
-		tailInBound = true
+		tailIsUnset = true
 	}
 
-	if headInBound || tailInBound {
+	if headIsUnset && tailIsUnset {
 		inBound = true
 	}
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -7,11 +7,16 @@ package stream
 // }
 
 type Stream[V any] interface {
+	// TODO: Consider:
+	// Current() (V, error)
+
 	Current() V
 	Prev()
 	Next()
+
 	Peek() (V, bool)
 	Append(V)
+
 	Eos() bool
 	Len() int
 }

--- a/table_data/table_data.go
+++ b/table_data/table_data.go
@@ -48,7 +48,7 @@ func (this *TableData) RowLength() int {
 // Get a specific cell by just indices.
 func (this *TableData) CellByIndices(t_row int, t_col int) (string, error) {
 	var cell string
-	defer func() { u.Logf("CellByIndices: %s.", u.Quote(cell)) }()
+	// defer func() { u.Logf("CellByIndices: %s.", u.Quote(cell)) }()
 
 	if t_row < this.RowLength() {
 		rowSlice := this.RowsData[t_row]
@@ -106,7 +106,7 @@ func (this *TableData) CellByColName(t_row int, t_name string) (string, error) {
 
 func (this *TableData) GetRow(t_row int) (TableDataRow, error) {
 	var row TableDataRow
-	defer func() { u.Logf("GetRow: %s.", u.Quote(row)) }()
+	// defer func() { u.Logf("GetRow: %s.", u.Quote(row)) }()
 
 	if t_row < this.RowLength() {
 		rowArray := this.RowsData[t_row]
@@ -164,12 +164,12 @@ func matrix2TableData(t_matrix [][]string) TableData {
 			table.Headers = append(table.Headers, header)
 			table.HeadersMap[header] = index
 
-			u.Logf("Header: (%d:%s)", index, header)
+			// u.Logf("Header: (%d:%s)", index, header)
 		}
 
 		// Initialize fields:
-		for index, row := range t_matrix[1:] {
-			u.Logf("Added row(%d): %v", index, row)
+		for _, row := range t_matrix[1:] {
+			// u.Logf("Added row(%d): %v", index, row)
 			table.RowsData = append(table.RowsData, row)
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -121,6 +121,13 @@ func FailIf(t_err error) {
 	}
 }
 
+// Panic in this case.
+func PanicIf(t_err error) {
+	if t_err != nil {
+		panic(t_err)
+	}
+}
+
 func Errorf(t_fmt string, t_args ...interface{}) error {
 	errStr := fmt.Sprintf(t_fmt, t_args...)
 


### PR DESCRIPTION
I need to add different sinks so that I can either write to a file or to stdout.
I will also need to figure out how to cleanly, swap these around.
Maybe just make stdout the default sink and then have it be swapped out.
When the accompanying IR is detected?
That would be the most clean way to do it.
I want stdout to be the default sink and then to have `>` operator to write to a file.
I need to also get rid of the bougs `json "filename.txt":` syntax as its stupid.